### PR TITLE
Add sample program for LED and capactive touch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,14 @@
 # Debug files
 *.dSYM/
 *.su
+
+# Tarballs/compressed files
+*.zip
+*.tar
+*.tar.gz
+*.tar.bz2
+
+# External libraries
+Gecko_SDK
+gcc-arm-none-eabi-5_4-2016q2
+

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -1,0 +1,155 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+################################################################################
+#
+# PATHS
+#
+ARM_BASE = gcc-arm-none-eabi-5_4-2016q2
+# You can download the ARM toolchain from:
+#   https://launchpad.net/gcc-arm-embedded/+download
+
+CC=$(ARM_BASE)/bin/arm-none-eabi-gcc
+OBJCOPY=$(ARM_BASE)/bin/arm-none-eabi-objcopy
+OBJDUMP=$(ARM_BASE)/bin/arm-none-eabi-objdump
+
+
+################################################################################
+#
+# ARGUMENTS TO COMPILERS/LINKERS
+#
+IFLAGS = -I. \
+				 -IGecko_SDK/cmsis/Include \
+				 -IGecko_SDK/Device/SiliconLabs/EFM32HG/Include \
+				 -IGecko_SDK/emlib/inc \
+				 -IGecko_SDK/kits/common/drivers
+
+CFLAGS = $(IFLAGS) \
+				 -DEFM32HG309F64 \
+				 -Wall \
+				 -Wextra \
+				 -mcpu=cortex-m0plus \
+				 -mthumb \
+				 -ffunction-sections \
+				 -fdata-sections \
+				 -fomit-frame-pointer \
+				 -std=c99 \
+				 -MMD \
+				 -MP \
+				 -O0 \
+				 -g
+
+LSCRIPT = Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/GCC/efm32hg.ld
+
+LFLAGS = -mcpu=cortex-m0plus \
+				 -mthumb \
+				 -T$(LSCRIPT) \
+				 --specs=nano.specs \
+				 -Wl,--gc-sections \
+				 -Wl,--start-group \
+				 -lgcc \
+				 -lc_nano \
+				 -lnosys \
+				 -Wl,--end-group
+
+
+################################################################################
+#
+# PHONY TARGETS
+#
+.PHONY: all blinky check clean deps
+
+all: blinky
+
+blinky: blinky.bin blinky.dump blinky.elf
+
+check:
+	@echo "Checking Gecko SDK linker script $(LSCRIPT) to ensure FLASH ORIGIN is set to 0x00004000..."
+	@grep -E '^\s*FLASH.*ORIGIN\s+=\s+0x' $(LSCRIPT)
+	@grep -q -E '^\s*FLASH.*ORIGIN\s+=\s+0x0*4000' $(LSCRIPT) || exit 1
+	@echo "Checking Gecko SDK linker script $(LSCRIPT) to ensure FLASH LENGTH is set to 0xC000..."
+	@grep -E '^\s*FLASH.*LENGTH\s+=\s+0x' $(LSCRIPT)
+	@grep -q -E '^\s*FLASH.*LENGTH\s+=\s+0x0*C000' $(LSCRIPT) || exit 1
+	@echo "Checking Gecko SDK linker script $(LSCRIPT) to ensure RAM ORIGIN is set to 0x20000000..."
+	@grep -E '^\s*RAM.*ORIGIN\s+=\s+0x' $(LSCRIPT)
+	@grep -q -E '^\s*RAM.*ORIGIN\s+=\s+0x20000000' $(LSCRIPT) || exit 1
+	@echo "Checking Gecko SDK linker script $(LSCRIPT) to ensure RAM LENGTH is set to 0x2000..."
+	@grep -E '^\s*RAM.*LENGTH\s+=\s+0x' $(LSCRIPT)
+	@grep -q -E '^\s*RAM.*LENGTH\s+=\s+0x0*2000' $(LSCRIPT) || exit 1
+	@echo "Checking ARM Toolchain is installed and accessible..."
+	@echo " -> GCC"
+	@test -x $(CC) || exit 1
+	@echo " -> OBJCOPY"
+	@test -x $(OBJCOPY) || exit 1
+	@echo " -> OBJDUMP"
+	@test -x $(OBJDUMP) || exit 1
+	@echo "All checks pass."
+
+clean:
+	@echo "Cleaning .bin files..."
+	@find Gecko_SDK -type f -name \*.bin -delete
+	@rm -f *.bin
+	@echo "Cleaning .dump files..."
+	@find Gecko_SDK -type f -name \*.dump -delete
+	@rm -f *.dump
+	@echo "Cleaning .d files..."
+	@find Gecko_SDK -type f -name \*.d -delete
+	@rm -f *.d
+	@echo "Cleaning .elf files..."
+	@find Gecko_SDK -type f -name \*.elf -delete
+	@rm -f *.elf
+	@echo "Cleaning .map files..."
+	@find Gecko_SDK -type f -name \*.map -delete
+	@rm -f *.map
+	@echo "Cleaning .o files..."
+	@find Gecko_SDK -type f -name \*.o -delete
+	@rm -f *.o
+
+deps:
+	@[ ! -d Gecko_SDK ] && git clone https://github.com/SiliconLabs/Gecko_SDK
+
+################################################################################
+#
+# REAL TARGETS // COMMON
+#
+GECKO_A_SRC = Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
+GECKO_C_SRC = $(shell find Gecko_SDK/emlib/src -name \*.c) \
+							Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
+							Gecko_SDK/kits/common/drivers/capsense.c
+GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
+						$(patsubst %.c,%.o,$(GECKO_C_SRC))
+
+%.o: %.c
+	@echo "    [CC] $^"
+	@$(CC) -c $(CFLAGS) -c -o $@ $<
+
+%.o: %.S
+	@echo "    [AS] $^"
+	@$(CC) -c $(CFLAGS) -c -o $@ $<
+
+
+################################################################################
+#
+# REAL TARGETS // CLEAN
+#
+blinky.elf: main.o $(GECKO_OBJ)
+	@echo "    [LD] (...) -> $@"
+	@$(CC) -Xlinker -Map=blinky.map $(LFLAGS) -o $@ $^
+	@$(OBJDUMP) -Sx $@ > blinky.dump
+
+blinky.bin: blinky.elf
+	@echo "    [OC] $< -> $@"
+	@$(OBJCOPY) -O binary $< $@
+

--- a/efm32hg-blinky/README.md
+++ b/efm32hg-blinky/README.md
@@ -1,0 +1,34 @@
+# Overview
+This code produces a program with which to test the LEDs and capacitive on the
+[tomu](http://tomu.im) board.  It will endlessly blink the green LED once, and
+the red LED twice. It will also respond to capacitive touch; when you touch
+either side of the board, it will make that side's LED blink ten times.
+
+# How to Compile
+Head over to http://launchpad.net/gcc-arm-embedded/+download to download the ARM
+toolchain for your platform.
+
+You will then need to edit the `Makefile` and point it to where you've extracted
+the toolchain.
+
+The `Makefile` can handle things from here. It will fetch the necessary
+dependencies, check that they're set up correctly, and compile them.
+
+```
+make deps
+make check  # resolve any issues with the linker script that have been identified
+make
+```
+
+# How to Flash
+Open up `minicom` (or whatever your favourite serial I/O utility is). Be sure to
+configure it to talk `115200 8n1` with no flow control. Confirm the bootloader
+on your tomu is responsive by pressing `i` and making sure you receive the
+identification prompt from the bootloader.
+
+Press `u` and the bootloader should report that it's `Ready`. Upload the
+`blinky.bin` file using XMODEM to your tomu, and then press `b` to boot into it.
+Remember that after striking `b`, the bootloader will no-op for 5-7 seconds to
+give you time to close your serial I/O utility, so there will be a delay before
+the LEDs start blinking.
+

--- a/efm32hg-blinky/capsenseconfig.h
+++ b/efm32hg-blinky/capsenseconfig.h
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains configuration/settings for the Gecko SDK-provided
+// "capsense" driver at Gecko_SDK/kits/common/drivers/capsense.c.
+
+#ifndef _CAPSENSECONFIG_H_
+#define _CAPSENSECONFIG_H_
+
+#define ACMP_CAPSENSE                       ACMP0
+#define ACMP_CAPSENSE_CLKEN                 CMU_HFPERCLKEN0_ACMP0
+#define PRS_CH_CTRL_SOURCESEL_ACMP_CAPSENSE PRS_CH_CTRL_SOURCESEL_ACMP0
+#define PRS_CH_CTRL_SIGSEL_ACMPOUT_CAPSENSE PRS_CH_CTRL_SIGSEL_ACMP0OUT
+
+#define ACMP_CHANNELS 8
+
+#define BUTTON0_CHANNEL 0
+#define BUTTON1_CHANNEL 1
+
+#define CAPSENSE_CH_IN_USE { true, true, false, false, false, false, false, false }
+
+#endif // _CAPSENSECONFIG_H_

--- a/efm32hg-blinky/main.c
+++ b/efm32hg-blinky/main.c
@@ -1,0 +1,127 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "capsense.h"
+#include "em_chip.h"
+#include "em_cmu.h"
+#include "em_device.h"
+#include "em_emu.h"
+#include "em_gpio.h"
+
+// The uptime of this application in milliseconds, maintained by the SysTick
+// timer.
+volatile uint32_t uptime_millis;
+
+// This functions is injected into the Interrupt Vector Table, and will be
+// called whenever the SysTick timer fires (whose interval is configured inside
+// main() further below).
+void SysTick_Handler() {
+  uptime_millis++;
+}
+
+void SpinDelay(uint32_t millis) {
+  // Calculate the time at which we need to finish "sleeping".
+  uint32_t sleep_until = uptime_millis + millis;
+
+  // Spin until the requested time has passed.
+  while (uptime_millis < sleep_until);
+}
+
+int main() {
+  // Runs the Silicon Labs chip initialisation stuff, that also deals with
+  // errata (implements workarounds, etc).
+  CHIP_Init();
+
+  // Switch on the clock for GPIO. Even though there's no immediately obvious
+  // timing stuff going on beyond the SysTick below, it still needs to be
+  // enabled for the GPIO to work.
+  CMU_ClockEnable(cmuClock_GPIO, true);
+
+  // Sets up and enable the `SysTick_Handler' interrupt to fire once every 1ms.
+  // ref: http://community.silabs.com/t5/Official-Blog-of-Silicon-Labs/Chapter-5-MCU-Clocking-Part-2-The-SysTick-Interrupt/ba-p/145297
+  if (SysTick_Config(CMU_ClockFreqGet(cmuClock_CORE) / 1000)) {
+    // Something went wrong.
+    while (1);
+  }
+
+  // Set up two pins with the GPIO controller and configure them to be open
+  // drain:
+  //  - PA0 == green
+  //  - PB7 == red
+  GPIO_PinModeSet(gpioPortA, 0, gpioModeWiredAnd, 0);
+  GPIO_PinModeSet(gpioPortB, 7, gpioModeWiredAnd, 0);
+
+  // Enable the capacitive touch sensor. Remember, this consumes TIMER0 and
+  // TIMER1, so those are off-limits to us.
+  CAPSENSE_Init();
+
+  // Blink infinitely, in an aviation-like pattern.
+  while (1) {
+    // Clear the PA0 bit, allowing the FET to sink to ground and thus lighting
+    // up the green LED.
+    GPIO_PinOutClear(gpioPortA, 0);
+    SpinDelay(100);
+
+    // Set the PA0 bit, preventing the FET from sinking to ground and thus
+    // switching the green LED off.
+    GPIO_PinOutSet(gpioPortA, 0);
+    SpinDelay(100);
+
+    // Repeat for the red LED on port PB7, but do so twice so that those that
+    // self-assemble their boards can be sure they've got the green and red LEDs
+    // around the right way.
+    GPIO_PinOutClear(gpioPortB, 7);
+    SpinDelay(100);
+    GPIO_PinOutSet(gpioPortB, 7);
+    SpinDelay(100);
+    GPIO_PinOutClear(gpioPortB, 7);
+    SpinDelay(100);
+    GPIO_PinOutSet(gpioPortB, 7);
+    SpinDelay(100);
+
+    SpinDelay(500);
+
+    // Capture/sample the state of the capacitive touch sensors.
+    CAPSENSE_Sense();
+
+    // Analyse the sample, and if the touch-pads on the green LED side is
+    // touched, rapid blink the green LED ten times.
+    if (CAPSENSE_getPressed(BUTTON0_CHANNEL) &&
+        !CAPSENSE_getPressed(BUTTON1_CHANNEL)) {
+      int i;
+      for (i = 10; i > 0; i--) {
+        GPIO_PinOutClear(gpioPortA, 0);
+        SpinDelay(100);
+        GPIO_PinOutSet(gpioPortA, 0);
+        SpinDelay(100);
+      }
+    // Analyse the same sample, and if the touch-pads on the red LED side is
+    // touched, rapid blink the red LED ten times.
+    } else if (CAPSENSE_getPressed(BUTTON1_CHANNEL) &&
+               !CAPSENSE_getPressed(BUTTON0_CHANNEL)) {
+      int i;
+      for (i = 10; i > 0; i--) {
+        GPIO_PinOutClear(gpioPortB, 7);
+        SpinDelay(100);
+        GPIO_PinOutSet(gpioPortB, 7);
+        SpinDelay(100);
+      }
+    }
+
+    SpinDelay(500);
+  }
+}


### PR DESCRIPTION
This sample program blinks the green and red LEDs (with differing
patterns, so as to identify they're around the right way: once for
green, twice for red), and responds to capacitve touch by blinking that
LED ten times.

Compiles to flash offset 0x4000, and is thus compatible with the EFM32
and EFM32HG Silicon Labs bootloaders.