### PR TITLE
Add (untested) support for UART output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.dylib
 
 # Executables
+*.bin
 *.exe
 *.out
 *.app
@@ -31,6 +32,9 @@
 # Debug files
 *.dSYM/
 *.su
+*.d
+*.dump
+*.map
 
 # Tarballs/compressed files
 *.zip

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -67,7 +67,6 @@ LFLAGS = -mcpu=cortex-m0plus \
 				 -Wl,--start-group \
 				 -lgcc \
 				 -lc_nano \
-				 -lnosys \
 				 -Wl,--end-group
 
 
@@ -133,7 +132,9 @@ deps:
 GECKO_A_SRC = Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
 GECKO_C_SRC = $(shell find Gecko_SDK/emlib/src -name \*.c) \
 							Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
-							Gecko_SDK/kits/common/drivers/capsense.c
+							Gecko_SDK/kits/common/drivers/capsense.c \
+							Gecko_SDK/kits/common/drivers/retargetio.c \
+							Gecko_SDK/kits/common/drivers/retargetserial.c
 GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
 						$(patsubst %.c,%.o,$(GECKO_C_SRC))
 

--- a/efm32hg-blinky/retargetserialconfig.h
+++ b/efm32hg-blinky/retargetserialconfig.h
@@ -1,0 +1,35 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains configuration/settings for the Gecko SDK-provided
+// "retargetserial" driver at Gecko_SDK/kits/common/drivers/retargetserial.c.
+
+#ifndef _RETARGETSERIALCONFIG_H
+#define _RETARGETSERIALCONFIG_H
+
+#define RETARGET_CLK      cmuClock_LEUART0
+#define RETARGET_IRQ_NAME LEUART0_IRQHandler
+#define RETARGET_IRQn     LEUART0_IRQn
+#define RETARGET_LEUART   1
+#define RETARGET_LOCATION LEUART_ROUTE_LOCATION_LOC1
+#define RETARGET_PERIPHERAL_ENABLE()
+#define RETARGET_RX       LEUART_Rx
+#define RETARGET_RXPIN    14
+#define RETARGET_RXPORT   gpioPortB
+#define RETARGET_TX       LEUART_Tx
+#define RETARGET_TXPIN    13
+#define RETARGET_TXPORT   gpioPortB
+#define RETARGET_UART     LEUART0
+
+#endif /* _RETARGETSERIALCONFIG_H */


### PR DESCRIPTION
I've not had time to test this nor will I anytime soon (I'm going on
vacation in a few days), but I'm quite confident that this will work
fine. The T and R pins on the board are wired to LEUART0 location 1, and
the Gecko SDK's retargetserial driver seems to do all the heavy lifting
capturing printf() output and writing it out the desired UART (see
retargetserialconfig.h for implementation details).
