### PR TITLE
Fix CROSS_COMPILE when using ccache

### DIFF
--- a/efm32hg-blinky-usb/Makefile
+++ b/efm32hg-blinky-usb/Makefile
@@ -26,7 +26,7 @@ endif
 #
 # Put the path to the arm-none-eabi toolchain that you downloaded here, up to
 # /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= $(patsubst %gcc,%,$(shell which arm-none-eabi-gcc))
+CROSS_COMPILE ?= $(patsubst %gcc,%,$(notdir $(shell which arm-none-eabi-gcc)))
 
 # You can download the ARM toolchain from:
 # https://launchpad.net/gcc-arm-embedded/+download

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -26,7 +26,7 @@ endif
 #
 # Put the path to the arm-none-eabi toolchain that you downloaded here, up to
 # /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= $(patsubst %gcc,%,$(shell which arm-none-eabi-gcc))
+CROSS_COMPILE ?= $(patsubst %gcc,%,$(notdir $(shell which arm-none-eabi-gcc)))
 
 # You can download the ARM toolchain from:
 # https://launchpad.net/gcc-arm-embedded/+download


### PR DESCRIPTION
If you use ccache, then the path to arm-none-eabi-gcc will be
/usr/lib/ccache/arm-none-eabi-gcc

The code to find CROSS_COMPILE already assumes that arm-none-eabi-gcc
is in your PATH.  It also assumes that arm-none-eabi-objcopy and
arm-none-eabi-objdump are in the same place.  This is not true: the
latter are both in /usr/bin (or somewhere else) in your PATH.

So strip off the path before using the variables. (It'd actually be simpler just to hard-code arm-none-eabi- )