### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Usee make V=1 for a verbose build.
-ifndef V
-        Q_CC		= @echo '      CC ' $@;
-        Q_OBJDUMP	= @echo ' OBJDUMP ' $@;
-        Q_OBJCOPY	= @echo ' OBJCOPY ' $@;
-endif
-
-################################################################################
-#
-# PATHS
-#
-# Put the path to the arm-none-eabi toolchain that you downloaded here, up to
-# /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= $(patsubst %gcc,%,$(shell which arm-none-eabi-gcc))
-
-
-# You can download the ARM toolchain from:
-# https://launchpad.net/gcc-arm-embedded/+download
-
-CC	= $(CROSS_COMPILE)gcc
-OBJCOPY	= $(CROSS_COMPILE)objcopy
-OBJDUMP	= $(CROSS_COMPILE)objdump
-
 ################################################################################
 #
 # Gecko

--- a/compile_flags.mk
+++ b/compile_flags.mk
@@ -1,0 +1,25 @@
+CFLAGS = $(IFLAGS) \
+				 -DEFM32HG309F64 \
+				 -Wall \
+				 -Wextra \
+				 -mcpu=cortex-m0plus \
+				 -mthumb \
+				 -ffunction-sections \
+				 -fdata-sections \
+				 -fomit-frame-pointer \
+				 -std=c99 \
+				 -MMD \
+				 -MP \
+				 -O0 \
+				 -g
+
+LSCRIPT = ../tomu.ld
+
+LFLAGS = -mcpu=cortex-m0plus \
+				 -mthumb \
+				 -T$(LSCRIPT) \
+				 --specs=nosys.specs \
+				 -Wl,--gc-sections \
+				 -Wl,--start-group \
+				 -lnosys \
+				 -Wl,--end-group

--- a/efm32hg-blinky-usb/Makefile
+++ b/efm32hg-blinky-usb/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Usee make V=1 for a verbose build.
+# Use make V=1 for a verbose build.
 ifndef V
         Q_CC		= @echo '      CC ' $@;
         Q_OBJDUMP	= @echo ' OBJDUMP ' $@;

--- a/efm32hg-blinky-usb/Makefile
+++ b/efm32hg-blinky-usb/Makefile
@@ -90,9 +90,10 @@ clean:
 #
 GECKO_A_SRC = ../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
 GECKO_C_SRC = $(shell [ -d ../Gecko_SDK ] && find ../Gecko_SDK/platform/emlib/src ../Gecko_SDK/platform/middleware/usb_gecko/src -name \*.c \! -name em_int.c ) \
-                                                  ../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
-                                                  ../Gecko_SDK/hardware/kit/common/drivers/capsense.c
-GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) $(patsubst %.c,%.o,$(GECKO_C_SRC))
+							../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
+							../Gecko_SDK/hardware/kit/common/drivers/capsense.c
+GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
+						$(patsubst %.c,%.o,$(GECKO_C_SRC))
 
 BLINKY_A_SRC = $(shell find . -maxdepth 1 -name \*.S)
 BLINKY_C_SRC = $(shell find . -maxdepth 1 -name \*.c)

--- a/efm32hg-blinky-usb/Makefile
+++ b/efm32hg-blinky-usb/Makefile
@@ -20,20 +20,8 @@ ifndef V
         Q_OBJCOPY	= @echo ' OBJCOPY ' $@;
 endif
 
-################################################################################
-#
-# PATHS
-#
-# Put the path to the arm-none-eabi toolchain that you downloaded here, up to
-# /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= $(patsubst %gcc,%,$(notdir $(shell which arm-none-eabi-gcc)))
-
-# You can download the ARM toolchain from:
-# https://launchpad.net/gcc-arm-embedded/+download
-
-CC	= $(CROSS_COMPILE)gcc
-OBJCOPY	= $(CROSS_COMPILE)objcopy
-OBJDUMP	= $(CROSS_COMPILE)objdump
+# Define CROSS_COMPILE, CC, OBJCOPY and OBJDUMP
+include ../paths.mk
 
 ################################################################################
 #

--- a/efm32hg-blinky-usb/Makefile
+++ b/efm32hg-blinky-usb/Makefile
@@ -34,32 +34,8 @@ IFLAGS = -I. \
 				 -I../Gecko_SDK/platform/middleware/usb_gecko/inc \
 				 -I../Gecko_SDK/hardware/kit/common/drivers
 
-CFLAGS = $(IFLAGS) \
-				 -DEFM32HG309F64 \
-				 -Wall \
-				 -Wextra \
-				 -mcpu=cortex-m0plus \
-				 -mthumb \
-				 -ffunction-sections \
-				 -fdata-sections \
-				 -fomit-frame-pointer \
-				 -std=c99 \
-				 -MMD \
-				 -MP \
-				 -O0 \
-				 -g
-
-LSCRIPT = ../tomu.ld
-
-LFLAGS = -mcpu=cortex-m0plus \
-				 -mthumb \
-				 --specs=nosys.specs \
-				 -T$(LSCRIPT) \
-				 -Wl,--gc-sections \
-				 -Wl,--start-group \
-				 -lnosys \
-				 -Wl,--end-group
-
+# Define CFLAGS, LSCRIPT and LFLAGS
+include ../compile_flags.mk
 
 ################################################################################
 #

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -33,32 +33,8 @@ IFLAGS = -I. \
 				 -I../Gecko_SDK/platform/emlib/inc \
 				 -I../Gecko_SDK/hardware/kit/common/drivers
 
-CFLAGS = $(IFLAGS) \
-				 -DEFM32HG309F64 \
-				 -Wall \
-				 -Wextra \
-				 -mcpu=cortex-m0plus \
-				 -mthumb \
-				 -ffunction-sections \
-				 -fdata-sections \
-				 -fomit-frame-pointer \
-				 -std=c99 \
-				 -MMD \
-				 -MP \
-				 -O0 \
-				 -g
-
-LSCRIPT = ../tomu.ld
-
-LFLAGS = -mcpu=cortex-m0plus \
-				 -mthumb \
-				 -T$(LSCRIPT) \
-				 --specs=nosys.specs \
-				 -Wl,--gc-sections \
-				 -Wl,--start-group \
-				 -lnosys \
-				 -Wl,--end-group
-
+# Define CFLAGS, LSCRIPT and LFLAGS
+include ../compile_flags.mk
 
 ################################################################################
 #

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Usee make V=1 for a verbose build.
+# Use make V=1 for a verbose build.
 ifndef V
         Q_CC		= @echo '      CC ' $@;
         Q_OBJDUMP	= @echo ' OBJDUMP ' $@;

--- a/efm32hg-blinky/Makefile
+++ b/efm32hg-blinky/Makefile
@@ -20,20 +20,8 @@ ifndef V
         Q_OBJCOPY	= @echo ' OBJCOPY ' $@;
 endif
 
-################################################################################
-#
-# PATHS
-#
-# Put the path to the arm-none-eabi toolchain that you downloaded here, up to
-# /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= $(patsubst %gcc,%,$(notdir $(shell which arm-none-eabi-gcc)))
-
-# You can download the ARM toolchain from:
-# https://launchpad.net/gcc-arm-embedded/+download
-
-CC	= $(CROSS_COMPILE)gcc
-OBJCOPY	= $(CROSS_COMPILE)objcopy
-OBJDUMP	= $(CROSS_COMPILE)objdump
+# Define CROSS_COMPILE, CC, OBJCOPY and OBJDUMP
+include ../paths.mk
 
 ################################################################################
 #

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -33,32 +33,8 @@ IFLAGS = -I. \
 				 -I../Gecko_SDK/platform/emlib/inc \
 				 -I../Gecko_SDK/hardware/kit/common/drivers
 
-CFLAGS = $(IFLAGS) \
-				 -DEFM32HG309F64 \
-				 -Wall \
-				 -Wextra \
-				 -mcpu=cortex-m0plus \
-				 -mthumb \
-				 -ffunction-sections \
-				 -fdata-sections \
-				 -fomit-frame-pointer \
-				 -std=c99 \
-				 -MMD \
-				 -MP \
-				 -O0 \
-				 -g
-
-LSCRIPT = ../tomu.ld
-
-LFLAGS = -mcpu=cortex-m0plus \
-				 -mthumb \
-				 -T$(LSCRIPT) \
-				 --specs=nosys.specs \
-				 -Wl,--gc-sections \
-				 -Wl,--start-group \
-				 -lnosys \
-				 -Wl,--end-group
-
+# Define CFLAGS, LSCRIPT and LFLAGS
+include ../compile_flags.mk
 
 ################################################################################
 #

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Usee make V=1 for a verbose build.
+# Use make V=1 for a verbose build.
 ifndef V
         Q_CC		= @echo '      CC ' $@;
         Q_OBJDUMP	= @echo ' OBJDUMP ' $@;

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -20,20 +20,8 @@ ifndef V
         Q_OBJCOPY	= @echo ' OBJCOPY ' $@;
 endif
 
-################################################################################
-#
-# PATHS
-#
-# Put the path to the arm-none-eabi toolchain that you downloaded here, up to
-# /bin/, and end with arm-none-eabi-
-CROSS_COMPILE ?= arm-none-eabi-
-
-# You can download the ARM toolchain from:
-# https://launchpad.net/gcc-arm-embedded/+download
-
-CC	= $(CROSS_COMPILE)gcc
-OBJCOPY	= $(CROSS_COMPILE)objcopy
-OBJDUMP	= $(CROSS_COMPILE)objdump
+# Define CROSS_COMPILE, CC, OBJCOPY and OBJDUMP
+include ../paths.mk
 
 ################################################################################
 #

--- a/paths.mk
+++ b/paths.mk
@@ -1,0 +1,15 @@
+################################################################################
+#
+# PATHS
+#
+# Put the full path to the arm-none-eabi-gcc binary here, without
+# the trailing "gcc"
+# E.g. CROSS_COMPILE = /bin/arm-none-eabi-
+CROSS_COMPILE ?= $(patsubst %gcc,%,$(shell which arm-none-eabi-gcc))
+
+# You can download the ARM toolchain from:
+# https://launchpad.net/gcc-arm-embedded/+download
+
+CC	= $(CROSS_COMPILE)gcc
+OBJCOPY	= $(CROSS_COMPILE)objcopy
+OBJDUMP	= $(CROSS_COMPILE)objdump


### PR DESCRIPTION
Changes:
- Remove unused PATHS and verbose build sections from top level Makefile
- Fix "Usee" typo
- Split CROSS_COMPILE, CC, OBJCOPY and OBJDUMP definitions into a separate Makefile, standardize CROSS_COMPILE definition to full path of arm-none-eabi-gcc, and update comments
- Split CFLAGS, LSCRIPT and LFLAGS definitions into a separate Makefile
- Reduce whitespace differences between efm32hg-blinky-usb/Makefile and other Makefiles