### PR TITLE
Documentation fix for fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ease your introduction to the Tomu platform.
 1. To compile these, you'll need a cross-compiling toolchain to arm-none-eabi.
 
   - Debian/Ubuntu/... : `sudo apt-get install gcc-arm-none-eabi`
-  - Fedora : `sudo yum install arm-none-eabi-gcc-cs`
+  - Fedora : `sudo yum install arm-none-eabi-gcc-cs arm-none-eabi-newlib`
   - Arch : `sudo pacman -S arm-none-eabi-gcc arm-none-eabi-newlib`
   - Other Linux : check your package manager, or
   - Anything else (Windows, OSX, Linux) : [https://developer.arm.com/open-source/gnu-toolchain/gnu-rm ](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm )
@@ -22,7 +22,9 @@ ease your introduction to the Tomu platform.
   There might be additional dependencies, depending on which specific project
   you're using, and the instructions for compilation are included in each
   project's README.md
+
 2. Run `make deps .` to patch the linker with support for the Tomu and clone the [Gecko SDK](https://github.com/SiliconLabs/Gecko_SDK) locally
+
 3. Now you can build the examples
 
 ## Flashing:


### PR DESCRIPTION
- Add missing package to avoid fatal compilation error about missing stdint.h
- Add missing blank lines for section breaks