### PR TITLE
libopencm3: modify makefile to build libopencm3-examples

### DIFF
--- a/libopencm3/.gitignore
+++ b/libopencm3/.gitignore
@@ -1,2 +1,1 @@
 libopencm3-examples
-libopencm3

--- a/libopencm3/Makefile
+++ b/libopencm3/Makefile
@@ -1,9 +1,9 @@
-
-all: libopencm3 libopencm3-examples
+all: libopencm3-examples
 	@true
 
-libopencm3:
-	git clone https://github.com/im-tomu/libopencm3.git
-
+# libopencm3-examples includes libopencm3 as a git submodule
 libopencm3-examples:
-	git clone https://github.com/im-tomu/libopencm3-examples.git
+	git clone --depth 1 https://github.com/im-tomu/libopencm3-examples.git --branch efm32hg
+	cd libopencm3-examples && git submodule init
+	cd libopencm3-examples && git submodule update
+	make -C libopencm3-examples

--- a/libopencm3/README.md
+++ b/libopencm3/README.md
@@ -21,5 +21,8 @@ for now you can find a copy in the
  * [libopencm3 with SiLabs EFM32 Happy Gecko + Tomu support.](https://github.com/im-tomu/libopencm3)
  * [libopencm3-examples with SiLabs EFM32 Happy Gecko + Tomu support.](https://github.com/im-tomu/libopencm3-examples)
 
-FIXME: Typing `make` should eventually download and compile these examples for
-you.
+# Building `libopencm3-examples`
+
+Typing `make` will download and compile these examples for you.
+
+The compiled binaries (and README.md about flashing) can then be found at `libopencm3-examples/examples/efm32/efm32hg/tomu-efm32hg309`


### PR DESCRIPTION
Just a small change so that the makefile in the `libopencm3` directory will clone & build `libopencm3-examples`.