### PR TITLE
Gnuk port on tomu (experimental)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "libopencm3"]
 	path = libopencm3
 	url = https://github.com/libopencm3/libopencm3
+[submodule "gnuk"]
+	path = gnuk
+	url = https://github.com/aze00/gnuk.git
+	branch = efm32

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
-all: libopencm3-samples
+all: libopencm3-samples gnuk
 	@true
+
+gnuk:
+	git submodule init
+	git submodule update --recursive
+	cd gnuk/src && ./configure --target=TOMU --vidpid=234b:0000
+	make -C gnuk/src
 
 libopencm3-samples:
 	git submodule init
@@ -21,4 +27,4 @@ clean:
 	make -C usb_midi clean
 	make -C usb_simple clean
 
-.PHONY: libopencm3-samples
+.PHONY: libopencm3-samples gnuk


### PR DESCRIPTION
This is still in early dev stage.

- only curve25516/ed25516 are supported.
- builds and fits in tomu flash/ram w/o a bootloader.
  - toboot + gnuk will be possible if flash is further reduced down by ~6kb
    this should be possible if the hw aes driver is implemented.
- builds and runs for linux emulation target with no regressions observed.

TODO:

- test on hardware
- hw aes implementation
- toboot compatibility
- merge back to upstream gnuk
  - improve configure and makefile for tomu
  - add options to disable crypto suites
  - add options to optimize code for size (do not unroll loops)