### PR TITLE
usb_simple: multiple cleanups

### DIFF
--- a/usb_simple/README.md
+++ b/usb_simple/README.md
@@ -1,4 +1,20 @@
 # README
 
-This is small USB controlled LED blinking example program using libopencm3.
-The usbtest.py script in this directory maybe used to control the LED.
+This is small USB controlled LED example program using libopencm3.
+
+The `usbtest.py` script in this directory may be used to control the LED.
+
+When connected, the device will appear as:
+
+```
+Manufacturer: "Tomu"
+Product Name: "USB Simple LED"
+Serial Number: "e018bf6d-0e3b-4f20-bf9f-c25ee5e0f769"
+```
+
+One may send a USB Control Transfers of a Vendor request type (0x40) in order to change the LED state:
+
+ * 0: Off
+ * 1: Green
+ * 2: Red
+ * 3: Green and Red

--- a/usb_simple/usbtest.py
+++ b/usb_simple/usbtest.py
@@ -1,20 +1,26 @@
 import usb.core
 
-if __name__ == "__main__":
+MODE = ['off', 'green', 'red', 'green+red']
+
+def main():
     dev = usb.core.find(idVendor=0x1209, idProduct=0x70b1)
 
     if dev is None:
-    	raise ValueError('Device not found')
+        raise ValueError('Device not found')
     dev.set_configuration()
 
-    from gi.repository import Gtk as gtk
-    w = gtk.Window()
-    w.connect("destroy", gtk.main_quit)
-    toggle = gtk.ToggleButton("Toggle LED")
-    def toggled(button):
-    	dev.ctrl_transfer(0x40, 0, button.get_active(), 0, 'Hello World!')
-    toggle.connect("toggled", toggled)
-    w.add(toggle)
-    w.show_all()
-    gtk.main()
+    state = 0
+    try:
+        while True:
+            # Send vendor request
+            dev.ctrl_transfer(0x40, 0, state, 0, '')
+            print('Light is ' + MODE[state])
+            print('Press ENTER to toggle, ^C to quit')
+            input()
+            state += 1
+            state %= 4
+    except KeyboardInterrupt:
+        pass
 
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Fix TOBOOT headers (so that it works with the current bootloader properly)
* Allow control of both lights
* Remove GTK dependency in example code
