### PR TITLE
Explicitly disable gnu build id during compilation

### DIFF
--- a/libopencm3_rules.mk
+++ b/libopencm3_rules.mk
@@ -128,6 +128,8 @@ TGT_LDFLAGS		+= -T$(LDSCRIPT)
 TGT_LDFLAGS		+= $(ARCH_FLAGS) $(DEBUG)
 TGT_LDFLAGS		+= -Wl,-Map=$(*).map -Wl,--cref
 TGT_LDFLAGS		+= -Wl,--gc-sections
+# Some distributions GCC will emit a gnu buildid section. Disable it always.
+TGT_LDFLAGS		+= -Wl,--build-id=none
 ifeq ($(V),99)
 TGT_LDFLAGS		+= -Wl,--print-gc-sections
 endif


### PR DESCRIPTION
On some platforms the gnu build id is enabled by default, and this causes
an extra section to be added to the resulting elf. This offsets the boot
loader by 0x24 bytes, which causes the flashed image to fail.

By default pass the -Wl,--build-id=none flags to the linker to prevent
this issue.