### PR TITLE
Add `--recursive` to Readme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ were modified to support the EFM32HG and tested on the Tomu with a Linux host:
 2. Fetch the required git submodules:
 
 ```
-git submodule init
-git submodule update
+git submodule update --init --recursive
 ```
 
 3. Run `make` to build all examples


### PR DESCRIPTION
If it is run without the `--recursive` flag, chopstx will not be checked out and it will fail to build. Also using `--init` saves us having to do two commands.