### PR TITLE
Make gecko-sdk examples work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@
 *.d
 
 # External libraries
-Gecko_SDK
+gecko_sdk
 gcc-arm-none-eabi-5_4-2016q2
 
 # Patched linker file

--- a/gecko-sdk/Makefile
+++ b/gecko-sdk/Makefile
@@ -17,7 +17,7 @@
 # Gecko
 #
 LSCRIPT = tomu.ld
-GECKO_SDK_REV = v5.0.0
+GECKO_SDK_REV = v4.0.2
 
 ################################################################################
 #
@@ -32,26 +32,26 @@ all:
 clean:
 	make -C efm32hg-blinky clean
 	make -C efm32hg-blinky-usb clean
-	@echo "Cleaning Gecko_SDK files..."
-	@find Gecko_SDK -type f -name \*.bin -delete
-	@find Gecko_SDK -type f -name \*.dump -delete
-	@find Gecko_SDK -type f -name \*.d -delete
-	@find Gecko_SDK -type f -name \*.elf -delete
-	@find Gecko_SDK -type f -name \*.map -delete
-	@find Gecko_SDK -type f -name \*.o -delete
+	@echo "Cleaning gecko_sdk files..."
+	@find gecko_sdk -type f -name \*.bin -delete
+	@find gecko_sdk -type f -name \*.dump -delete
+	@find gecko_sdk -type f -name \*.d -delete
+	@find gecko_sdk -type f -name \*.elf -delete
+	@find gecko_sdk -type f -name \*.map -delete
+	@find gecko_sdk -type f -name \*.o -delete
 
 
 dist-clean:
 	make clean || true
-	rm -rf Gecko_SDK
+	rm -rf gecko_sdk
 	rm tomu.ld
 
 deps:
-	@if [ ! -d Gecko_SDK ]; then \
-		git clone --depth 1 https://github.com/SiliconLabs/Gecko_SDK --branch ${GECKO_SDK_REV}; \
+	@if [ ! -d gecko_sdk ]; then \
+		git clone --depth 1 https://github.com/SiliconLabs/gecko_sdk --branch ${GECKO_SDK_REV}; \
 	fi
 	@if [ ! -f "${LSCRIPT}" ]; then \
 		echo "Patching linker file to ${LSCRIPT}"; \
-		patch -o ${LSCRIPT} Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/GCC/efm32hg.ld linker.patch; \
+		patch -o ${LSCRIPT} gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/GCC/efm32hg.ld linker.patch; \
 	fi
 

--- a/gecko-sdk/efm32hg-blinky-usb/Makefile
+++ b/gecko-sdk/efm32hg-blinky-usb/Makefile
@@ -28,11 +28,11 @@ include ../paths.mk
 # ARGUMENTS TO COMPILERS/LINKERS
 #
 IFLAGS = -I. \
-				 -I../Gecko_SDK/platform/CMSIS/Include \
-				 -I../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Include \
-				 -I../Gecko_SDK/platform/emlib/inc \
-				 -I../Gecko_SDK/platform/middleware/usb_gecko/inc \
-				 -I../Gecko_SDK/hardware/kit/common/drivers
+				 -I../gecko_sdk/platform/CMSIS/Include \
+				 -I../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Include \
+				 -I../gecko_sdk/platform/emlib/inc \
+				 -I../gecko_sdk/platform/middleware/usb_gecko/inc \
+				 -I../gecko_sdk/hardware/kit/common/drivers
 
 # Define CFLAGS, LSCRIPT and LFLAGS
 include ../compile_flags.mk
@@ -88,10 +88,10 @@ clean:
 #
 # REAL TARGETS // COMMON
 #
-GECKO_A_SRC = ../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
-GECKO_C_SRC = $(shell [ -d ../Gecko_SDK ] && find ../Gecko_SDK/platform/emlib/src ../Gecko_SDK/platform/middleware/usb_gecko/src -name \*.c \! -name em_int.c ) \
-							../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
-							../Gecko_SDK/hardware/kit/common/drivers/capsense.c
+GECKO_A_SRC = ../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
+GECKO_C_SRC = $(shell [ -d ../gecko_sdk ] && find ../gecko_sdk/platform/emlib/src ../gecko_sdk/platform/middleware/usb_gecko/src -name \*.c \! -name em_int.c ) \
+							../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
+							../gecko_sdk/hardware/kit/common/drivers/capsense.c
 GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
 						$(patsubst %.c,%.o,$(GECKO_C_SRC))
 

--- a/gecko-sdk/efm32hg-blinky/Makefile
+++ b/gecko-sdk/efm32hg-blinky/Makefile
@@ -28,10 +28,10 @@ include ../paths.mk
 # ARGUMENTS TO COMPILERS/LINKERS
 #
 IFLAGS = -I. \
-				 -I../Gecko_SDK/platform/CMSIS/Include \
-				 -I../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Include \
-				 -I../Gecko_SDK/platform/emlib/inc \
-				 -I../Gecko_SDK/hardware/kit/common/drivers
+				 -I../gecko_sdk/platform/CMSIS/Include \
+				 -I../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Include \
+				 -I../gecko_sdk/platform/emlib/inc \
+				 -I../gecko_sdk/hardware/kit/common/drivers
 
 # Define CFLAGS, LSCRIPT and LFLAGS
 include ../compile_flags.mk
@@ -87,10 +87,10 @@ clean:
 #
 # REAL TARGETS // COMMON
 #
-GECKO_A_SRC = ../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
-GECKO_C_SRC = $(shell [ -d ../Gecko_SDK ] && find ../Gecko_SDK/platform/emlib/src -name \*.c \! -name em_int.c) \
-							../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
-							../Gecko_SDK/hardware/kit/common/drivers/capsense.c
+GECKO_A_SRC = ../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
+GECKO_C_SRC = $(shell [ -d ../gecko_sdk ] && find ../gecko_sdk/platform/emlib/src -name \*.c \! -name em_int.c) \
+							../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
+							../gecko_sdk/hardware/kit/common/drivers/capsense.c
 GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
 						$(patsubst %.c,%.o,$(GECKO_C_SRC))
 

--- a/gecko-sdk/hello/Makefile
+++ b/gecko-sdk/hello/Makefile
@@ -28,10 +28,10 @@ include ../paths.mk
 # ARGUMENTS TO COMPILERS/LINKERS
 #
 IFLAGS = -I. \
-				 -I../Gecko_SDK/platform/CMSIS/Include \
-				 -I../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Include \
-				 -I../Gecko_SDK/platform/emlib/inc \
-				 -I../Gecko_SDK/hardware/kit/common/drivers
+				 -I../gecko_sdk/platform/CMSIS/Include \
+				 -I../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Include \
+				 -I../gecko_sdk/platform/emlib/inc \
+				 -I../gecko_sdk/hardware/kit/common/drivers
 
 # Define CFLAGS, LSCRIPT and LFLAGS
 include ../compile_flags.mk
@@ -91,10 +91,10 @@ clean:
 #
 # REAL TARGETS // COMMON
 #
-GECKO_A_SRC = ../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
-GECKO_C_SRC = $(shell [ -d ../Gecko_SDK ] && find ../Gecko_SDK/platform/emlib/src -name \*.c \! -name em_int.c) \
-							../Gecko_SDK/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
-							../Gecko_SDK/hardware/kit/common/drivers/capsense.c
+GECKO_A_SRC = ../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/GCC/startup_efm32hg.S
+GECKO_C_SRC = $(shell [ -d ../gecko_sdk ] && find ../gecko_sdk/platform/emlib/src -name \*.c \! -name em_int.c) \
+							../gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/system_efm32hg.c \
+							../gecko_sdk/hardware/kit/common/drivers/capsense.c
 GECKO_OBJ = $(patsubst %.S,%.o,$(GECKO_A_SRC)) \
 						$(patsubst %.c,%.o,$(GECKO_C_SRC))
 

--- a/gecko-sdk/linker.patch
+++ b/gecko-sdk/linker.patch
@@ -1,6 +1,6 @@
---- Gecko_SDK/Device/SiliconLabs/EFM32HG/Source/GCC/efm32hg.ld	2017-01-02 16:25:06.000000000 +0100
-+++ tomu.ld	2017-01-02 16:30:02.000000000 +0100
-@@ -11,8 +11,8 @@
+--- gecko_sdk/platform/Device/SiliconLabs/EFM32HG/Source/GCC/efm32hg.ld
++++ tomu.ld
+@@ -29,8 +29,8 @@
  
  MEMORY
  {


### PR DESCRIPTION
It seems that the upstream [gecko_sdk](https://github.com/SiliconLabs/gecko_sdk) repo recently had, at some point, been renamed and, its history rewritten or something similar - I was unable to find any references to `v5.0.0`. In any case, I was unable to build the samples out-of-the-box. 

Here is a minimal patch that builds the samples against v4.0.2 instead.

Tested by building the `efm32hg-blinky-usb` sample, and checking it runs it on a real Tomu.