### PR TITLE
simple_usb: Document Windows setup, use libusb_package.

### DIFF
--- a/usb_simple/README.md
+++ b/usb_simple/README.md
@@ -2,24 +2,7 @@
 
 This is small USB controlled LED example program using libopencm3.
 
-The `usbtest.py` script in this directory may be used to control the LED.
-
-When connected, the device will appear as:
-
-```
-Manufacturer: "Tomu"
-Product Name: "USB Simple LED"
-Serial Number: "e018bf6d-0e3b-4f20-bf9f-c25ee5e0f769"
-```
-
-One may send a USB Control Transfers of a Vendor request type (0x40) in order to change the LED state:
-
- * 0: Off
- * 1: Green
- * 2: Red
- * 3: Green and Red
-
-## Flashing to a device with autorun
+## Flashing to a Tomu with autorun
 
 To build and flash `usb_simple` with autorun enabled, so you don't need to flash on power-on:
 
@@ -29,3 +12,48 @@ dfu-util -d 1209:70b1 -D usb_simple.bin
 ```
 
 If you want to be able to reflash this, you need to [short the two outer pads on power-on](https://github.com/im-tomu/tomu-bootloader#entering-toboot).
+
+## Controlling the LED
+
+The `usbtest.py` script in this directory may be used to control the LED with [`pyusb`][pyusb] and
+`libusb`.
+
+If you're running Windows, [you'll _also_ need to assign the `WinUsb` driver](#windows-driver) to
+the Tomu Simple USB to make it work.
+
+Linux and macOS do not require any drivers.
+
+When connected, the device will appear as:
+
+```
+Manufacturer: "Tomu"
+Product Name: "USB Simple LED"
+Serial Number: "e018bf6d-0e3b-4f20-bf9f-c25ee5e0f769"
+```
+
+You can send a USB Control Transfers of a Vendor request type (0x40) in order to change the LED state:
+
+* 0: Off
+* 1: Green
+* 2: Red
+* 3: Green and Red
+
+## Windows driver
+
+You'll need to assign the `WinUsb` driver to the Tomu in order to control it:
+
+1. Open `Device Manager`
+1. Expand `Other devices`
+1. Right-click `USB Simple LED` and select `Update driver`
+1. Click `Browse my computer for drivers`
+1. Click `Let me pick from a list of available drivers on my computer`
+1. Under `Manufacturer`, click `WinUsb Device`
+1. Under `Model`, click `WinUsb Device`
+1. Click `Next`
+1. Windows will warn that installing the driver is not recommended because it cannot verify that it is compatible. Click `Yes` to continue installing the driver.
+
+The `USB Simple LED` device should now move to the `Universal Serial Bus devices` section, and you
+should be able to control the LED with the `usbtest.py` script above.
+
+[pyusb]: https://pypi.org/project/pyusb/
+

--- a/usb_simple/README.md
+++ b/usb_simple/README.md
@@ -18,8 +18,8 @@ If you want to be able to reflash this, you need to [short the two outer pads on
 The `usbtest.py` script in this directory may be used to control the LED with [`pyusb`][pyusb] and
 `libusb`.
 
-If you're running Windows, [you'll _also_ need to assign the `WinUsb` driver](#windows-driver) to
-the Tomu Simple USB to make it work.
+If you're running Windows, you'll _also_ need to install `libusb-package` with `pip` and
+[assign the `WinUsb` driver](#windows-driver) to the Tomu Simple USB to make it work.
 
 Linux and macOS do not require any drivers.
 

--- a/usb_simple/usbtest.py
+++ b/usb_simple/usbtest.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-import usb.core
+try:
+    import libusb_package as usb
+except ImportError:
+    from usb import core as usb
 
 MODE = ['off', 'green', 'red', 'green+red']
 
 def main():
-    dev = usb.core.find(idVendor=0x1209, idProduct=0x70b1)
+    dev = usb.find(idVendor=0x1209, idProduct=0x70b1)
 
     if dev is None:
         raise ValueError('Device not found')


### PR DESCRIPTION
Windows needs a driver assigned to the device to make it work.